### PR TITLE
Add repeat day

### DIFF
--- a/pad_api_data/pad_etl/common/dungeon_types.py
+++ b/pad_api_data/pad_etl/common/dungeon_types.py
@@ -56,3 +56,12 @@ DUNGEON_TYPE_COMMENTS = {
     600011: 'Multiplayer',
 }
 
+REPEAT_DAY = {
+    0: '', # Doesn't repeat weekly
+    1:'Monday',
+    2:'Tuesday',
+    3:'Wednesday',
+    4:'Thursday',
+    5:'Friday',
+    8:'Weekend'
+}

--- a/pad_api_data/pad_etl/common/dungeon_types.py
+++ b/pad_api_data/pad_etl/common/dungeon_types.py
@@ -1,0 +1,77 @@
+DUNGEON_TYPE = {
+    0: 'Normal Dungeon',
+    1: 'Special Dungeon',
+    2: 'Technical Dungeon',
+    3: 'Gift Dungeon',
+    4: 'Tournament Dungeon',
+    5: 'Special Descended Dungeon',
+    7: 'Multiplayer Dungeon',
+}
+
+
+# These for sure might need a rename/reclassification. I gave them as best a designation as I could
+DUNGEON_TYPE_DESCRIPTORS = {
+    0: 'Normal',  # Something to do with them at least
+    1: 'Special Descended',
+    2: 'Endless',
+    23101: 'Alt. Technical',
+    23111: "Last Technical",  # Before the "Legendary Series"
+    31001: 'Annihilation Technical',
+    31002: 'Annihilation Descended',
+    32001: 'Endless',
+    30001: 'Challenge Machine Technical',  # When there are MZeus/Hera/Etc in the Challenge Series
+    30002: 'Descended Rush',
+    30011: 'Arena',  # Specifically Ultimate and Alt. Ultimate
+    30012: 'Super Ultimate Colosseum',
+    38908: 'The Thief Descended',  # Only
+    49001: 'One-Shot Challenge',
+    60001: 'Daily Descend',  # I think, as in, are in the daily rotation?
+    60002: 'One-Shot Challenge',
+    60102: 'Metal Dragon',
+    150001: 'King Carnival',
+    200011: 'Mythical Endless Corridors',
+    200207: 'Super Ultimate Dragon Rush',
+    200601: 'Machine Technical',
+    201902: "Ultimate Yamato Rush (alpha)",
+    202002: "Super Ultimate Devil Rush (alpha)",
+    210001: 'Coin',
+    210002: 'Challenge',
+    210004: "PAD Academy",
+    210006: 'Time Attack Dungeon',
+    210011: 'Collab',
+    210051: 'Event Challenge',
+    220001: 'Challenge',
+    290001: 'Monthly Quest',
+    299902: 'Tues-Fri Dungeon',
+    299911: 'Metal Dragon',
+    300001: 'Daily',
+    400001: 'Guerrilla',
+    490001: 'GachaDra',
+    500001: 'Gift/Daily Event',
+    500011: 'Gift/Daily Event',
+    600001: 'Multiplayer Endless Corridors',
+    600002: 'Multiplayer Evo Rush',
+    600003: 'Multiplayer Descended',
+    600004: 'Multiplayer Special Descended',
+    600011: 'Multiplayer',
+}
+
+# Simply returns a comment for a input raw value. Doing it this way is necessary as to not have to put all the values
+# directly into a dictionary when multiple val's correspond to a single comment, but are unnecessarily delineated
+def get_dungeon_description(val):
+    if val in range(5611, 5615):
+        return "Retired Special Dungeons"  # These are the last normal dungeons
+    elif val in range(21612, 21618):
+        return "Technical"
+    elif val in range(38901, 38912):
+        return "Descended (original)"
+    elif val in range(200101, 200111):
+        return "Alt. Technial"
+    elif val in range(200021, 200057):
+        return "Technical"
+    elif val in range(200301, 200306) or val in range(200201, 200206):
+        return "Special Decended"
+    elif val in DUNGEON_TYPE_DESCRIPTORS:
+        return DUNGEON_TYPE_DESCRIPTORS[val]
+    else:
+        return "No Data"

--- a/pad_api_data/pad_etl/common/dungeon_types.py
+++ b/pad_api_data/pad_etl/common/dungeon_types.py
@@ -58,7 +58,7 @@ DUNGEON_TYPE_DESCRIPTORS = {
 
 # Simply returns a comment for a input raw value. Doing it this way is necessary as to not have to put all the values
 # directly into a dictionary when multiple val's correspond to a single comment, but are unnecessarily delineated
-def get_dungeon_description(val):
+def get_dungeon_comment(val):
     if val in range(5611, 5615):
         return "Retired Special Dungeons"  # These are the last normal dungeons
     elif val in range(21612, 21618):

--- a/pad_api_data/pad_etl/common/dungeon_types.py
+++ b/pad_api_data/pad_etl/common/dungeon_types.py
@@ -10,7 +10,7 @@ DUNGEON_TYPE = {
 
 
 # These for sure might need a rename/reclassification. I gave them as best a designation as I could
-DUNGEON_TYPE_DESCRIPTORS = {
+DUNGEON_TYPE_COMMENTS = {
     0: 'Normal',  # Something to do with them at least
     1: 'Special Descended',
     2: 'Endless',
@@ -56,22 +56,3 @@ DUNGEON_TYPE_DESCRIPTORS = {
     600011: 'Multiplayer',
 }
 
-# Simply returns a comment for a input raw value. Doing it this way is necessary as to not have to put all the values
-# directly into a dictionary when multiple val's correspond to a single comment, but are unnecessarily delineated
-def get_dungeon_comment(val):
-    if val in range(5611, 5615):
-        return "Retired Special Dungeons"  # These are the last normal dungeons
-    elif val in range(21612, 21618):
-        return "Technical"
-    elif val in range(38901, 38912):
-        return "Descended (original)"
-    elif val in range(200101, 200111):
-        return "Alt. Technial"
-    elif val in range(200021, 200057):
-        return "Technical"
-    elif val in range(200301, 200306) or val in range(200201, 200206):
-        return "Special Decended"
-    elif val in DUNGEON_TYPE_DESCRIPTORS:
-        return DUNGEON_TYPE_DESCRIPTORS[val]
-    else:
-        return "No Data"

--- a/pad_api_data/pad_etl/common/pad_util.py
+++ b/pad_api_data/pad_etl/common/pad_util.py
@@ -1,6 +1,7 @@
 import datetime
 import json
 import re
+from .dungeon_types import DUNGEON_TYPE_COMMENTS
 
 
 def strip_colors(message: int) -> str:
@@ -60,3 +61,23 @@ class JsonDictEncodable(json.JSONEncoder):
 
     def default(self, o):
         return o.__dict__
+
+# Simply returns a dungeon comment for a input raw value. Doing it this way is necessary as to not have to put all the values
+# directly into a dictionary when multiple val's correspond to a single comment, but are unnecessarily delineated
+def get_dungeon_comment(val):
+    if val in range(5611, 5615):
+        return "Retired Special Dungeons"  # These are the last normal dungeons
+    elif val in range(21612, 21618):
+        return "Technical"
+    elif val in range(38901, 38912):
+        return "Descended (original)"
+    elif val in range(200101, 200111):
+        return "Alt. Technial"
+    elif val in range(200021, 200057):
+        return "Technical"
+    elif val in range(200301, 200306) or val in range(200201, 200206):
+        return "Special Decended"
+    elif val in DUNGEON_TYPE_COMMENTS:
+        return DUNGEON_TYPE_COMMENTS[val]
+    else:
+        return "No Data"

--- a/pad_api_data/pad_etl/common/pad_util.py
+++ b/pad_api_data/pad_etl/common/pad_util.py
@@ -64,7 +64,7 @@ class JsonDictEncodable(json.JSONEncoder):
 
 # Simply returns a dungeon comment for a input raw value. Doing it this way is necessary as to not have to put all the values
 # directly into a dictionary when multiple val's correspond to a single comment, but are unnecessarily delineated
-def get_dungeon_comment(val):
+def get_dungeon_comment(val: int) -> str:
     if val in range(5611, 5615):
         return "Retired Special Dungeons"  # These are the last normal dungeons
     elif val in range(21612, 21618):

--- a/pad_api_data/pad_etl/data/dungeon.py
+++ b/pad_api_data/pad_etl/data/dungeon.py
@@ -9,6 +9,7 @@ import os
 from typing import List, Any
 
 from ..common import pad_util
+from ..common.dungeon_types import DUNGEON_TYPE, get_dungeon_description
 
 
 # The typical JSON file name for this data.
@@ -54,14 +55,20 @@ class Dungeon(pad_util.JsonDictEncodable):
 
         self.dungeon_id = int(raw[0])
         self.name = str(raw[1])
-
         self.unknown_002 = int(raw[2])
-        self.unknown_003 = int(raw[3])
         self.unknown_004 = int(raw[4])
-        self.unknown_005 = int(raw[5])
 
         self.clean_name = pad_util.strip_colors(self.name)
-        self.dungeon_type = None  # type: str
+
+
+        # Using DUNGEON TYPES file in common.dungeon_types
+        self.dungeon_type = DUNGEON_TYPE[int(raw[3])]
+
+        # I call it comment as it is similar to dungeon_type, but sometimes designates certain dungeons specifically
+        # over others. See dungeon_types.py for more details.
+        self.dungeon_comment = get_dungeon_description(int(raw[5]))
+
+
         self.prefix = None  # type: str
 
         for prefix, dungeon_type in prefix_to_dungeontype.items():

--- a/pad_api_data/pad_etl/data/dungeon.py
+++ b/pad_api_data/pad_etl/data/dungeon.py
@@ -9,8 +9,7 @@ import os
 from typing import List, Any
 
 from ..common import pad_util
-from ..common.dungeon_types import DUNGEON_TYPE
-
+from ..common.dungeon_types import DUNGEON_TYPE, REPEAT_DAY
 
 # The typical JSON file name for this data.
 FILE_NAME = 'download_dungeon_data.json'
@@ -44,10 +43,8 @@ class Dungeon(pad_util.JsonDictEncodable):
         self.dungeon_id = int(raw[0])
         self.name = str(raw[1])
         self.unknown_002 = int(raw[2])
-        self.unknown_004 = int(raw[4])
 
         self.clean_name = pad_util.strip_colors(self.name)
-
 
         # Using DUNGEON TYPES file in common.dungeon_types
         self.dungeon_type = DUNGEON_TYPE[int(raw[3])]
@@ -55,6 +52,9 @@ class Dungeon(pad_util.JsonDictEncodable):
         # I call it comment as it is similar to dungeon_type, but sometimes designates certain dungeons specifically
         # over others. See dungeon_types.py for more details.
         self.dungeon_comment = pad_util.get_dungeon_comment(int(raw[5]))
+
+        # This will be a day of the week, or an empty string if it doesn't repeat regularly
+        self.repeat_day = REPEAT_DAY[int(raw[4])]
 
         if len(raw) > 6:
             print('unexpected field count: ' + ','.join(raw))
@@ -66,7 +66,7 @@ class Dungeon(pad_util.JsonDictEncodable):
         return 'Dungeon({} - {})'.format(self.dungeon_id, self.clean_name)
 
 
-def load_dungeon_data(data_dir: str=None, dungeon_file: str=None) -> List[Dungeon]:
+def load_dungeon_data(data_dir: str = None, dungeon_file: str = None) -> List[Dungeon]:
     """Converts dungeon JSON into an array of Dungeons."""
     if dungeon_file is None:
         dungeon_file = os.path.join(data_dir, FILE_NAME)

--- a/pad_api_data/pad_etl/data/dungeon.py
+++ b/pad_api_data/pad_etl/data/dungeon.py
@@ -9,7 +9,7 @@ import os
 from typing import List, Any
 
 from ..common import pad_util
-from ..common.dungeon_types import DUNGEON_TYPE, get_dungeon_comment
+from ..common.dungeon_types import DUNGEON_TYPE
 
 
 # The typical JSON file name for this data.
@@ -35,18 +35,6 @@ class DungeonFloor(pad_util.JsonDictEncodable):
         self.unknown_010 = raw[10]
 
 
-prefix_to_dungeontype = {
-    # #G#Ruins of the Star Vault 25
-    '#G#': 'guerrilla',
-
-    # #1#Star Treasure of the Night Sky 25
-    '#1#': 'unknown-1',
-
-    # #C#Rurouni Kenshin dung
-    '#C#': 'collab',
-}
-
-
 class Dungeon(pad_util.JsonDictEncodable):
     """A top-level dungeon."""
 
@@ -66,17 +54,7 @@ class Dungeon(pad_util.JsonDictEncodable):
 
         # I call it comment as it is similar to dungeon_type, but sometimes designates certain dungeons specifically
         # over others. See dungeon_types.py for more details.
-        self.dungeon_comment = get_dungeon_comment(int(raw[5]))
-
-
-        self.prefix = None  # type: str
-
-        for prefix, dungeon_type in prefix_to_dungeontype.items():
-            if self.clean_name.startswith(prefix):
-                self.prefix = prefix
-                self.dungeon_type = dungeon_type
-                self.clean_name = self.clean_name[len(prefix):]
-                break
+        self.dungeon_comment = pad_util.get_dungeon_comment(int(raw[5]))
 
         if len(raw) > 6:
             print('unexpected field count: ' + ','.join(raw))

--- a/pad_api_data/pad_etl/data/dungeon.py
+++ b/pad_api_data/pad_etl/data/dungeon.py
@@ -9,7 +9,7 @@ import os
 from typing import List, Any
 
 from ..common import pad_util
-from ..common.dungeon_types import DUNGEON_TYPE, get_dungeon_description
+from ..common.dungeon_types import DUNGEON_TYPE, get_dungeon_comment
 
 
 # The typical JSON file name for this data.
@@ -66,7 +66,7 @@ class Dungeon(pad_util.JsonDictEncodable):
 
         # I call it comment as it is similar to dungeon_type, but sometimes designates certain dungeons specifically
         # over others. See dungeon_types.py for more details.
-        self.dungeon_comment = get_dungeon_description(int(raw[5]))
+        self.dungeon_comment = get_dungeon_comment(int(raw[5]))
 
 
         self.prefix = None  # type: str


### PR DESCRIPTION
Looks like unknown_004 represents the day of the week a dungeon repeats on. I've added in support for this in dungeon.py as a result. 

 I spent time trying to figure out what they are, because I saw the same numbers repeatedly popping up. 

In essence, I added a file to pad_etl/common called dungeon_types.py, which has a map for Dungeon Types directly (Normal, Special, Tech, etc) for unknown_003,  as well as a function, get_dungeon_comment(), that returns a short comment about the dungeon depending on the input, for unknown_005. 

Because there are many unknown_005 values that all fall under the same category, but have been separated for whatever reason, I wrote a function to check various ranges rather than hard coding them all into a map.

The names of the comments are, of course, up for any changes. I tried to give them a description depending on what they were, but as you can see, some descends, like "The Thief Descended," (38908) have their own value for some reason.

I believe this should be fine, as I can't find any direct dependencies on the unknown_003/5  anywhere else in the code, but that might just be me missing something.

Also, feel free to restructure in whatever way is normal for you. I tried to follow how you seemed to have organized your codebase.